### PR TITLE
Implementing SPI signal synchronisation

### DIFF
--- a/extras/rtl/Makefile
+++ b/extras/rtl/Makefile
@@ -12,6 +12,8 @@ analyze:
 	ghdl -a grpRgbLed/unitRgbLedEncoder/RgbLedEncoder-Rtl-a.vhd
 	ghdl -a unitSynchronizer/Synchronizer-e.vhd
 	ghdl -a unitSynchronizer/Synchronizer-Rtl-a.vhd
+	ghdl -a grpSpi/unitSpiSynchronizer/SpiSynchronizer-e.vhd
+	ghdl -a grpSpi/unitSpiSynchronizer/SpiSynchronizer-Rtl-a.vhd
 	ghdl -a -P=altera_mf/ ../ip/syspll.vhd
 	ghdl -a unitViperQuadcopterTop/ViperQuadcopterTop-e.vhd
 	ghdl -a unitViperQuadcopterTop/ViperQuadcopterTop-Rtl-a.vhd

--- a/extras/rtl/grpSpi/unitSpiSynchronizer/SpiSynchronizer-Rtl-a.vhd
+++ b/extras/rtl/grpSpi/unitSpiSynchronizer/SpiSynchronizer-Rtl-a.vhd
@@ -1,0 +1,47 @@
+---------------------------------------------------------------
+-- Viper Quadcopter MKR VIDOR 4000 FPGA Code
+-- (C) Alexander Entinger, MSc / LXRobotics GmbH
+-- GNU LGPL V3.0
+---------------------------------------------------------------
+
+library ieee;
+use ieee.numeric_std.all;
+
+library work;
+use work.viper.all;
+
+---------------------------------------------------------------
+
+architecture Rtl of SpiSynchronizer is
+
+begin
+
+    mosi_sync : entity work.Synchronizer(Rtl)
+    port map
+    (
+        iClk => iClk,
+        inReset => inReset,
+        iData => iMosiAsync,
+        oData => oMosiSync
+    );
+
+    sck_sync : entity work.Synchronizer(Rtl)
+    port map
+    (
+        iClk => iClk,
+        inReset => inReset,
+        iData => iSckAsync,
+        oData => oSckSync
+    );
+
+    ncs_sync : entity work.Synchronizer(Rtl)
+    port map
+    (
+        iClk => iClk,
+        inReset => inReset,
+        iData => inCsAsync,
+        oData => onCsSync
+    );
+
+end Rtl;
+  

--- a/extras/rtl/grpSpi/unitSpiSynchronizer/SpiSynchronizer-Rtl-a.vhd
+++ b/extras/rtl/grpSpi/unitSpiSynchronizer/SpiSynchronizer-Rtl-a.vhd
@@ -44,4 +44,3 @@ begin
     );
 
 end Rtl;
-  

--- a/extras/rtl/grpSpi/unitSpiSynchronizer/SpiSynchronizer-e.vhd
+++ b/extras/rtl/grpSpi/unitSpiSynchronizer/SpiSynchronizer-e.vhd
@@ -1,0 +1,23 @@
+---------------------------------------------------------------
+-- Viper Quadcopter MKR VIDOR 4000 FPGA Code
+-- (C) Alexander Entinger, MSc / LXRobotics GmbH
+-- GNU LGPL V3.0
+---------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity SpiSynchronizer is
+  port (
+    iClk       : in  std_ulogic;
+    inReset    : in  std_ulogic;
+
+    iMosiAsync : in  std_ulogic;
+    iSckAsync  : in  std_ulogic;
+    inCsAsync  : in  std_ulogic;
+
+    oMosiSync  : out std_ulogic;
+    oSckSync   : out std_ulogic;
+    onCsSync   : out std_ulogic
+  );
+end SpiSynchronizer;

--- a/extras/rtl/unitViperQuadcopterTop/ViperQuadcopterTop-Rtl-a.vhd
+++ b/extras/rtl/unitViperQuadcopterTop/ViperQuadcopterTop-Rtl-a.vhd
@@ -12,6 +12,11 @@ architecture Rtl of ViperQuadcopterTop is
   signal pll_clock_c0_192MHz : std_ulogic;
   signal pll_locked          : std_ulogic;
 
+  -- SPI sync signals
+  signal iMosiSync : std_ulogic;
+  signal iSckSync : std_ulogic;
+  signal inCsSync : std_ulogic;
+  
 begin
 
   rgb_led_encoder : entity work.RgbLedEncoder(Rtl)
@@ -30,6 +35,19 @@ begin
     inclk0 => iClk,
     c0     => pll_clock_c0_192MHz,
     locked => pll_locked
+  );
+
+  spisync_inst : entity work.SpiSynchronizer(Rtl)
+  port map
+  (
+      iClk       => iClk,
+      inReset    => pll_locked,
+      iMosiAsync => iMOSI,
+      iSckAsync  => iSCK,
+      inCsAsync  => inCS,
+      oMosiSync  => iMosiSync,
+      oSckSync   => iSckSync,
+      onCsSync   => inCsSync
   );
 
 end Rtl;


### PR DESCRIPTION
Incoming SPI signals are asynchronous and need to be put through a synchronizer chain to avoid metastability.